### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ bower install bootstrap-selectsplitter
 ## CDN
 
 ```HTML
-<script src="//cdn.jsdelivr.net/bootstrap.selectsplitter/0.1.4/bootstrap-selectsplitter.min.js"></script>
+<script src="//cdn.jsdelivr.net/gh/xavierfaucon/bootstrap-selectsplitter@0.1.4/bootstrap-selectsplitter.min.js"></script>
 ```
 
 ## Changes


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/gh/xavierfaucon/bootstrap-selectsplitter.

Feel free to ping me if you have any questions regarding this change.